### PR TITLE
Mark generated class as resolved to BODY_RESOLVE

### DIFF
--- a/src/org/demiurg906/kotlin/plugin/fir/SimpleClassGenerator.kt
+++ b/src/org/demiurg906/kotlin/plugin/fir/SimpleClassGenerator.kt
@@ -41,6 +41,7 @@ class SimpleClassGenerator(session: FirSession) : FirDeclarationGenerationExtens
     override fun generateTopLevelClassLikeDeclaration(classId: ClassId): FirClassLikeSymbol<*>? {
         if (classId != MY_CLASS_ID) return null
         val klass = buildRegularClass {
+            resolvePhase = FirResolvePhase.BODY_RESOLVE
             moduleData = session.moduleData
             origin = Key.origin
             status = FirResolvedDeclarationStatusImpl(


### PR DESCRIPTION
Otherwise this class will cause exceptions in IDE, like this one:

```stacktrace
In file: file:///Users/roman.golyshev/JetBrains/Issues/KTIJ-27574-generated-declarations-not-in-completion/kotlin-compiler-usage/src/Main.kt

org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments: Error while resolving org.jetbrains.kotlin.fir.declarations.impl.FirSimpleFunctionImpl 
from ANNOTATION_ARGUMENTS to BODY_RESOLVE
current declaration phase ANNOTATION_ARGUMENTS
origin: Source
session: class org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSourcesSession
module data: class org.jetbrains.kotlin.analysis.low.level.api.fir.project.structure.LLFirModuleData
KtModule: class org.jetbrains.kotlin.idea.base.projectStructure.KtSourceModuleByModuleInfo
platform: JVM (1.8)

	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolverKt.handleExceptionFromResolve(LLFirModuleLazyDeclarationResolver.kt:286)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolverKt.access$handleExceptionFromResolve(LLFirModuleLazyDeclarationResolver.kt:1)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolver.lazyResolve(LLFirModuleLazyDeclarationResolver.kt:289)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.LLFirLazyDeclarationResolver.lazyResolveToPhase(LLFirLazyDeclarationResolver.kt:26)
	at org.jetbrains.kotlin.fir.symbols.FirLazyDeclarationResolverKt.lazyResolveToPhase(FirLazyDeclarationResolver.kt:89)
	at org.jetbrains.kotlin.fir.symbols.FirLazyDeclarationResolverKt.lazyResolveToPhase(FirLazyDeclarationResolver.kt:98)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.file.structure.FileStructure.createDeclarationStructure(FileStructure.kt:171)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.file.structure.FileStructure.createStructureElement(FileStructure.kt:216)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.file.structure.FileStructure.getStructureElementFor(FileStructure.kt:66)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.element.builder.FirElementBuilder.getFirForNonKtFileElement(FirElementBuilder.kt:112)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.element.builder.FirElementBuilder.getOrBuildFirFor(FirElementBuilder.kt:85)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.state.LLFirResolvableResolveSession.getOrBuildFirFor$low_level_api_fir(LLFirResolvableResolveSession.kt:48)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.api.LowLevelFirApiFacadeKt.getOrBuildFir(LowLevelFirApiFacade.kt:100)
	at org.jetbrains.kotlin.analysis.api.fir.components.KtFirSmartcastProvider.getMatchingFirQualifiedAccessExpression(KtFirSmartcastProvider.kt:80)
	at org.jetbrains.kotlin.analysis.api.fir.components.KtFirSmartcastProvider.getImplicitReceiverSmartCast(KtFirSmartcastProvider.kt:89)
	at org.jetbrains.kotlin.analysis.api.components.KtSmartCastProviderMixIn.getImplicitReceiverSmartCast(KtSmartCastProvider.kt:39)
	at org.jetbrains.kotlin.idea.highlighting.highlighters.ExpressionsSmartcastHighlighter.highlightExpression(ExpressionsSmartcastHighlighter.kt:20)
	at org.jetbrains.kotlin.idea.highlighting.highlighters.ExpressionsSmartcastHighlighter.visitExpression(ExpressionsSmartcastHighlighter.kt:16)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitExpression(KtVisitorVoid.java:667)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitExpression(KtVisitorVoid.java:21)
	at org.jetbrains.kotlin.psi.KtVisitor.visitReferenceExpression(KtVisitor.java:202)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitReferenceExpression(KtVisitorVoid.java:189)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitReferenceExpression(KtVisitorVoid.java:691)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitReferenceExpression(KtVisitorVoid.java:21)
	at org.jetbrains.kotlin.psi.KtVisitor.visitSimpleNameExpression(KtVisitor.java:198)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitSimpleNameExpression(KtVisitorVoid.java:185)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitSimpleNameExpression(KtVisitorVoid.java:685)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitSimpleNameExpression(KtVisitorVoid.java:21)
	at org.jetbrains.kotlin.psi.KtNameReferenceExpression.accept(KtNameReferenceExpression.kt:59)
	at org.jetbrains.kotlin.psi.KtElementImplStub.accept(KtElementImplStub.java:49)
	at org.jetbrains.kotlin.idea.highlighting.KotlinSemanticHighlightingVisitor.visit(KotlinSemanticHighlightingVisitor.kt:46)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.runVisitors(GeneralHighlightingPass.java:361)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$collectHighlights$7(GeneralHighlightingPass.java:292)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:321)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$analyzeByVisitors$8(GeneralHighlightingPass.java:324)
	at org.jetbrains.kotlin.idea.highlighting.KotlinSemanticHighlightingVisitor.analyze(KotlinSemanticHighlightingVisitor.kt:29)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:324)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$analyzeByVisitors$8(GeneralHighlightingPass.java:324)
	at org.jetbrains.kotlin.idea.highlighting.KotlinDiagnosticHighlightVisitor.analyze(KotlinDiagnosticHighlightVisitor.kt:44)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:324)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.lambda$analyzeByVisitors$8(GeneralHighlightingPass.java:324)
	at com.intellij.codeInsight.daemon.impl.DefaultHighlightVisitor.analyze(DefaultHighlightVisitor.java:90)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.analyzeByVisitors(GeneralHighlightingPass.java:324)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectHighlights(GeneralHighlightingPass.java:287)
	at com.intellij.codeInsight.daemon.impl.GeneralHighlightingPass.collectInformationWithProgress(GeneralHighlightingPass.java:234)
	at com.intellij.codeInsight.daemon.impl.ProgressableTextEditorHighlightingPass.doCollectInformation(ProgressableTextEditorHighlightingPass.java:80)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:55)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$1(PassExecutorService.java:406)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.runWithSpanIgnoreThrows(trace.kt:76)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceUtil.runWithSpanThrows(TraceUtil.java:34)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$2(PassExecutorService.java:401)
	at com.intellij.openapi.application.impl.RwLockHolder.tryRunReadAction(RwLockHolder.kt:293)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:928)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$doRun$3(PassExecutorService.java:392)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:610)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:685)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:641)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:609)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:78)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.doRun(PassExecutorService.java:391)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.lambda$run$0(PassExecutorService.java:367)
	at com.intellij.openapi.application.impl.ReadMostlyRWLock.executeByImpatientReader(ReadMostlyRWLock.java:200)
	at com.intellij.openapi.application.impl.RwLockHolder.executeByImpatientReader(RwLockHolder.kt:452)
	at com.intellij.openapi.application.impl.ApplicationImpl.executeByImpatientReader(ApplicationImpl.java:180)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:365)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:188)
	at java.base/java.util.concurrent.ForkJoinTask.doExec$$$capture(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
Caused by: org.jetbrains.kotlin.utils.exceptions.KotlinIllegalArgumentExceptionWithAttachments: Error while resolving org.jetbrains.kotlin.fir.declarations.impl.FirRegularClassImpl 
from RAW_FIR to SUPER_TYPES
current declaration phase RAW_FIR
origin: Plugin[org.demiurg906.kotlin.plugin.fir.SimpleClassGenerator$Key@14f9bd06]
session: class org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSourcesSession
module data: class org.jetbrains.kotlin.analysis.low.level.api.fir.project.structure.LLFirModuleData
KtModule: class org.jetbrains.kotlin.idea.base.projectStructure.KtSourceModuleByModuleInfo
platform: JVM (1.8)

	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolverKt.handleExceptionFromResolve(LLFirModuleLazyDeclarationResolver.kt:286)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolverKt.access$handleExceptionFromResolve(LLFirModuleLazyDeclarationResolver.kt:1)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolver.lazyResolve(LLFirModuleLazyDeclarationResolver.kt:289)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.LLFirLazyDeclarationResolver.lazyResolveToPhase(LLFirLazyDeclarationResolver.kt:26)
	at org.jetbrains.kotlin.fir.symbols.FirLazyDeclarationResolverKt.lazyResolveToPhase(FirLazyDeclarationResolver.kt:89)
	at org.jetbrains.kotlin.fir.symbols.FirLazyDeclarationResolverKt.lazyResolveToPhase(FirLazyDeclarationResolver.kt:98)
	at org.jetbrains.kotlin.fir.resolve.SupertypeSupplier$Default.forClass(SupertypeUtils.kt:39)
	at org.jetbrains.kotlin.fir.resolve.SupertypeUtilsKt.collectSuperTypes(SupertypeUtils.kt:247)
	at org.jetbrains.kotlin.fir.resolve.SupertypeUtilsKt.lookupSuperTypes(SupertypeUtils.kt:91)
	at org.jetbrains.kotlin.fir.resolve.SupertypeUtilsKt.lookupSuperTypes$default(SupertypeUtils.kt:82)
	at org.jetbrains.kotlin.fir.scopes.FirKotlinScopeProvider.getUseSiteMemberScope(FirKotlinScopeProvider.kt:72)
	at org.jetbrains.kotlin.fir.scopes.FirKotlinScopeProviderKt.unsubstitutedScope(FirKotlinScopeProvider.kt:127)
	at org.jetbrains.kotlin.fir.scopes.FirKotlinScopeProviderKt.scopeForClassImpl(FirKotlinScopeProvider.kt:205)
	at org.jetbrains.kotlin.fir.scopes.FirKotlinScopeProviderKt.scopeForClass(FirKotlinScopeProvider.kt:147)
	at org.jetbrains.kotlin.fir.resolve.calls.ConstructorProcessingKt.processConstructors(ConstructorProcessing.kt:196)
	at org.jetbrains.kotlin.fir.resolve.calls.ConstructorProcessingKt.processConstructorsByName(ConstructorProcessing.kt:41)
	at org.jetbrains.kotlin.fir.resolve.calls.ConstructorProcessingKt.processFunctionsAndConstructorsByName(ConstructorProcessing.kt:64)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.ScopeTowerLevel.processFunctionsByName(TowerLevels.kt:432)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.TowerLevelHandler.handleLevel(TowerLevelHandler.kt:60)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.FirBaseTowerResolveTask.processLevel(FirTowerResolveTask.kt:196)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.FirBaseTowerResolveTask.access$processLevel(FirTowerResolveTask.kt:60)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.FirBaseTowerResolveTask$processLevel$3.invokeSuspend(FirTowerResolveTask.kt)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.TowerResolveManager.resumeTask(TowerResolveManager.kt:77)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.TowerResolveManager.runTasks(TowerResolveManager.kt:83)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.FirTowerResolver.runResolver(FirTowerResolver.kt:45)
	at org.jetbrains.kotlin.fir.resolve.calls.tower.FirTowerResolver.runResolver(FirTowerResolver.kt:32)
	at org.jetbrains.kotlin.fir.FirCallResolver.collectCandidates(FirCallResolver.kt:179)
	at org.jetbrains.kotlin.fir.FirCallResolver.collectCandidates$default(FirCallResolver.kt:151)
	at org.jetbrains.kotlin.fir.FirCallResolver.resolveCallAndSelectCandidate(FirCallResolver.kt:79)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer$transformFunctionCallInternal$1$resultExpression$1.invoke(FirExpressionsResolveTransformer.kt:432)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer$transformFunctionCallInternal$1$resultExpression$1.invoke(FirExpressionsResolveTransformer.kt:431)
	at org.jetbrains.kotlin.fir.resolve.inference.FirInferenceSession.onCandidatesResolution(FirInferenceSession.kt:46)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformFunctionCallInternal$resolve(FirExpressionsResolveTransformer.kt:431)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformFunctionCall(FirExpressionsResolveTransformer.kt:387)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformFunctionCall(FirAbstractBodyResolveTransformerDispatcher.kt:156)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformFunctionCall(FirAbstractBodyResolveTransformerDispatcher.kt:22)
	at org.jetbrains.kotlin.fir.expressions.FirFunctionCall.transform(FirFunctionCall.kt:45)
	at org.jetbrains.kotlin.fir.expressions.impl.FirFunctionCallImpl.transformExplicitReceiver(FirFunctionCallImpl.kt:88)
	at org.jetbrains.kotlin.fir.expressions.impl.FirFunctionCallImpl.transformExplicitReceiver(FirFunctionCallImpl.kt:30)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformExplicitReceiver(FirExpressionsResolveTransformer.kt:206)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformFunctionCallInternal$resolve(FirExpressionsResolveTransformer.kt:422)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformFunctionCall(FirExpressionsResolveTransformer.kt:387)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformFunctionCall(FirAbstractBodyResolveTransformerDispatcher.kt:156)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformFunctionCall(FirAbstractBodyResolveTransformerDispatcher.kt:22)
	at org.jetbrains.kotlin.fir.expressions.FirFunctionCall.transform(FirFunctionCall.kt:45)
	at org.jetbrains.kotlin.fir.visitors.FirTransformerUtilKt.transformInplace(FirTransformerUtil.kt:20)
	at org.jetbrains.kotlin.fir.expressions.impl.FirArgumentListImpl.transformArguments(FirArgumentListImpl.kt:31)
	at org.jetbrains.kotlin.fir.expressions.impl.FirArgumentListImpl.transformChildren(FirArgumentListImpl.kt:26)
	at org.jetbrains.kotlin.fir.expressions.impl.FirArgumentListImpl.transformChildren(FirArgumentListImpl.kt:17)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformElement(FirAbstractBodyResolveTransformerDispatcher.kt:77)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformElement(FirAbstractBodyResolveTransformerDispatcher.kt:22)
	at org.jetbrains.kotlin.fir.visitors.FirTransformer.transformArgumentList(FirTransformer.kt:461)
	at org.jetbrains.kotlin.fir.expressions.FirArgumentList.transform(FirArgumentList.kt:28)
	at org.jetbrains.kotlin.fir.expressions.impl.FirStringConcatenationCallImpl.transformChildren(FirStringConcatenationCallImpl.kt:41)
	at org.jetbrains.kotlin.fir.expressions.impl.FirStringConcatenationCallImpl.transformChildren(FirStringConcatenationCallImpl.kt:26)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformStringConcatenationCall(FirExpressionsResolveTransformer.kt:1646)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformStringConcatenationCall(FirAbstractBodyResolveTransformerDispatcher.kt:165)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformStringConcatenationCall(FirAbstractBodyResolveTransformerDispatcher.kt:22)
	at org.jetbrains.kotlin.fir.expressions.FirStringConcatenationCall.transform(FirStringConcatenationCall.kt:32)
	at org.jetbrains.kotlin.fir.visitors.FirTransformerUtilKt.transformInplace(FirTransformerUtil.kt:20)
	at org.jetbrains.kotlin.fir.expressions.impl.FirArgumentListImpl.transformArguments(FirArgumentListImpl.kt:31)
	at org.jetbrains.kotlin.fir.expressions.impl.FirArgumentListImpl.transformChildren(FirArgumentListImpl.kt:26)
	at org.jetbrains.kotlin.fir.expressions.impl.FirArgumentListImpl.transformChildren(FirArgumentListImpl.kt:17)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformElement(FirAbstractBodyResolveTransformerDispatcher.kt:77)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformElement(FirAbstractBodyResolveTransformerDispatcher.kt:22)
	at org.jetbrains.kotlin.fir.visitors.FirTransformer.transformArgumentList(FirTransformer.kt:461)
	at org.jetbrains.kotlin.fir.expressions.FirArgumentList.transform(FirArgumentList.kt:28)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirPartialBodyResolveTransformer.transformElement(FirPartialBodyResolveTransformer.kt:36)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirPartialBodyResolveTransformer.transformElement(FirPartialBodyResolveTransformer.kt:13)
	at org.jetbrains.kotlin.fir.visitors.FirTransformer.transformArgumentList(FirTransformer.kt:461)
	at org.jetbrains.kotlin.fir.expressions.FirArgumentList.transform(FirArgumentList.kt:28)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformFunctionCallInternal$resolve(FirExpressionsResolveTransformer.kt:424)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformFunctionCall(FirExpressionsResolveTransformer.kt:387)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformFunctionCall(FirAbstractBodyResolveTransformerDispatcher.kt:156)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformFunctionCall(FirAbstractBodyResolveTransformerDispatcher.kt:22)
	at org.jetbrains.kotlin.fir.expressions.FirFunctionCall.transform(FirFunctionCall.kt:45)
	at org.jetbrains.kotlin.fir.expressions.FirExpressionUtilKt.transformStatementsIndexed(FirExpressionUtil.kt:222)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformBlockInCurrentScope$resolve(FirExpressionsResolveTransformer.kt:526)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirExpressionsResolveTransformer.transformBlock(FirExpressionsResolveTransformer.kt:517)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformBlock(FirAbstractBodyResolveTransformerDispatcher.kt:183)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformBlock(FirAbstractBodyResolveTransformerDispatcher.kt:22)
	at org.jetbrains.kotlin.fir.expressions.FirBlock.transform(FirBlock.kt:32)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirPartialBodyResolveTransformer.transformElement(FirPartialBodyResolveTransformer.kt:36)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirPartialBodyResolveTransformer.transformElement(FirPartialBodyResolveTransformer.kt:13)
	at org.jetbrains.kotlin.fir.visitors.FirTransformer.transformBlock(FirTransformer.kt:405)
	at org.jetbrains.kotlin.fir.expressions.FirBlock.transform(FirBlock.kt:32)
	at org.jetbrains.kotlin.fir.declarations.impl.FirSimpleFunctionImpl.transformBody(FirSimpleFunctionImpl.kt:118)
	at org.jetbrains.kotlin.fir.declarations.impl.FirSimpleFunctionImpl.transformBody(FirSimpleFunctionImpl.kt:41)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirDeclarationsResolveTransformer.transformFunction(FirDeclarationsResolveTransformer.kt:851)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirDeclarationsResolveTransformer.transformFunctionWithGivenSignature(FirDeclarationsResolveTransformer.kt:801)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirDeclarationsResolveTransformer.access$transformFunctionWithGivenSignature(FirDeclarationsResolveTransformer.kt:58)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirDeclarationsResolveTransformer$transformSimpleFunction$1$1$1.invoke(FirDeclarationsResolveTransformer.kt:793)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirDeclarationsResolveTransformer$transformSimpleFunction$1$1$1.invoke(FirDeclarationsResolveTransformer.kt:791)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.BodyResolveContext.forFunctionBody(BodyResolveContext.kt:1163)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirDeclarationsResolveTransformer.transformSimpleFunction(FirDeclarationsResolveTransformer.kt:791)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformSimpleFunction(FirAbstractBodyResolveTransformerDispatcher.kt:496)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirAbstractBodyResolveTransformerDispatcher.transformSimpleFunction(FirAbstractBodyResolveTransformerDispatcher.kt:22)
	at org.jetbrains.kotlin.fir.declarations.FirSimpleFunction.transform(FirSimpleFunction.kt:55)
	at org.jetbrains.kotlin.fir.visitors.FirTransformerUtilKt.transformSingle(FirTransformerUtil.kt:13)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirAbstractBodyTargetResolver.rawResolve(LLFirAbstractBodyTargetResolver.kt:84)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirBodyTargetResolver.rawResolve(LLFirBodyLazyResolver.kt:265)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirAbstractBodyTargetResolver.resolve(LLFirAbstractBodyTargetResolver.kt:79)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirBodyTargetResolver.doLazyResolveUnderLock(LLFirBodyLazyResolver.kt:246)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirTargetResolver.performResolve(LLFirTargetResolver.kt:79)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirTargetResolver.performAction(LLFirTargetResolver.kt:73)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.api.targets.LLFirSingleResolveTarget.visitTargetElement(LLFirSingleResolveTarget.kt:26)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.api.targets.LLFirResolveTarget.goToTarget(LLFirResolveTarget.kt:78)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.api.targets.LLFirResolveTarget.access$goToTarget(LLFirResolveTarget.kt:26)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.api.targets.LLFirResolveTarget$visit$1.invoke(LLFirResolveTarget.kt:60)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.api.targets.LLFirResolveTarget$visit$1.invoke(LLFirResolveTarget.kt:58)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirAbstractBodyTargetResolver$withFile$1.invoke(LLFirAbstractBodyTargetResolver.kt:61)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirAbstractBodyTargetResolver$withFile$1.invoke(LLFirAbstractBodyTargetResolver.kt:60)
	at org.jetbrains.kotlin.fir.resolve.transformers.body.resolve.FirDeclarationsResolveTransformer.withFile(FirDeclarationsResolveTransformer.kt:708)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirAbstractBodyTargetResolver.withFile(LLFirAbstractBodyTargetResolver.kt:60)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.api.targets.LLFirResolveTarget.visit(LLFirResolveTarget.kt:58)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirTargetResolver.resolveDesignation(LLFirTargetResolver.kt:69)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirBodyLazyResolver.resolve(LLFirBodyLazyResolver.kt:69)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirLazyResolverRunner$runLazyResolverByPhase$1$1.invoke(LLFirLazyResolverRunner.kt:27)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirLazyResolverRunner$runLazyResolverByPhase$1$1.invoke(LLFirLazyResolverRunner.kt:26)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.file.builder.LLFirLockProvider.withGlobalPhaseLock(LLFirLockProvider.kt:51)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.transformers.LLFirLazyResolverRunner.runLazyResolverByPhase(LLFirLazyResolverRunner.kt:26)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolver.lazyResolveTargets(LLFirModuleLazyDeclarationResolver.kt:197)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolver.lazyResolve(LLFirModuleLazyDeclarationResolver.kt:282)
	... 69 more
Caused by: java.lang.IllegalStateException: Expected body resolve phase for origin Plugin[org.demiurg906.kotlin.plugin.fir.SimpleClassGenerator$Key@14f9bd06] but found ResolvedTo(RAW_FIR)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirResolveMultiDesignationCollector.shouldBeResolved(LLFirResolveMultiDesignationCollector.kt:98)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirResolveMultiDesignationCollector.shouldBeResolved(LLFirResolveMultiDesignationCollector.kt:67)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirResolveMultiDesignationCollector.getMainDesignationToResolve(LLFirResolveMultiDesignationCollector.kt:56)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirResolveMultiDesignationCollector.getDesignationsToResolve(LLFirResolveMultiDesignationCollector.kt:27)
	at org.jetbrains.kotlin.analysis.low.level.api.fir.lazy.resolve.LLFirModuleLazyDeclarationResolver.lazyResolve(LLFirModuleLazyDeclarationResolver.kt:44)
	... 190 more
```